### PR TITLE
vitaGxm: Small rendering improvements

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -148,9 +148,7 @@ void
 StartDrawing(SDL_Renderer *renderer)
 {
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
-    if(data->drawing)
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "uh-oh, already drawing\n");
+    if (data->drawing) {
         return;
     }
 
@@ -993,9 +991,6 @@ VITA_GXM_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *
         cmd = cmd->next;
     }
 
-    sceGxmEndScene(data->gxm_context, NULL, NULL);
-    data->drawing = SDL_FALSE;
-
     return 0;
 }
 
@@ -1090,6 +1085,11 @@ VITA_GXM_RenderPresent(SDL_Renderer *renderer)
 {
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
     SceCommonDialogUpdateParam updateParam;
+
+    if(data->drawing) {
+        sceGxmEndScene(data->gxm_context, NULL, NULL);
+        sceGxmFinish(data->gxm_context);
+    }
 
     data->displayData.address = data->displayBufferData[data->backBufferIndex];
 

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -115,8 +115,8 @@ SDL_RenderDriver VITA_GXM_RenderDriver = {
             [1] = SDL_PIXELFORMAT_ARGB8888,
             [2] = SDL_PIXELFORMAT_RGB888,
             [3] = SDL_PIXELFORMAT_BGR888,
-            [2] = SDL_PIXELFORMAT_RGB565,
-            [3] = SDL_PIXELFORMAT_BGR565
+            [4] = SDL_PIXELFORMAT_RGB565,
+            [5] = SDL_PIXELFORMAT_BGR565
         },
         .max_texture_width = 1024,
         .max_texture_height = 1024,
@@ -1086,9 +1086,11 @@ VITA_GXM_RenderPresent(SDL_Renderer *renderer)
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
     SceCommonDialogUpdateParam updateParam;
 
-    if(data->drawing) {
+    if (data->drawing) {
         sceGxmEndScene(data->gxm_context, NULL, NULL);
-        sceGxmFinish(data->gxm_context);
+        if (data->displayData.wait_vblank) {
+            sceGxmFinish(data->gxm_context);
+        }
     }
 
     data->displayData.address = data->displayBufferData[data->backBufferIndex];


### PR DESCRIPTION
1. Improve performance for unbatched rendering
2. Support direct texture access without graphical glitches

-----

Specifics:

**1:** The code was recreating and ending the rendering context every time `RunCommandQueue` was called. While this worked well for batched rendering (the default since SDL 2.0.9), if the flag `SDL_HINT_RENDER_BATCHING` was set to `0` (or if some `SDL_Render` operation required the renderer to be flushed, such as `SDL_RenderFlush`) rendering would be much slower than needed.

By only creating and ending the render context once per frame, performance is improved.

-----

**2:** Due to the way texture memory is directly accessible by the program, `SDL_UnlockTexture` is unneeded. This also means that, when using `SDL_LockTexture` on Vita, the texture's memory pointer can be stored to be directly accessed and changed from the program even in subsequent frames.

However, in this new SDL implementation, direct texture access might cause the memory to be updated while the screen was being rendered, resulting in noticeable visual artifacts, like flickering (because, for example, only half the texture's memory had been filled with new data by the time rendering occured).

Adding `sceGxmFinish` to `RenderPresent` fixes that without adding any noticeable performance impact. In addition, it might also fix the problems with hardware framebuffer, but I didn't test that.