### PR TITLE
Allow larger texture sizes

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -118,8 +118,8 @@ SDL_RenderDriver VITA_GXM_RenderDriver = {
             [4] = SDL_PIXELFORMAT_RGB565,
             [5] = SDL_PIXELFORMAT_BGR565
         },
-        .max_texture_width = 1024,
-        .max_texture_height = 1024,
+        .max_texture_width = 4096,
+        .max_texture_height = 4096,
      }
 };
 


### PR DESCRIPTION
@isage:

Vita allows larger texture sizes than `1024x1024`.

Since vita2d uses `4096x4096` as a max, that's what I used here.